### PR TITLE
Fix name of directory for neovim's bundle deps

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -36,7 +36,7 @@ jobs:
           cd "$NEOVIM_DIR"
           mkdir deps
           cd deps
-          cmake -G Ninja -DUSE_BUNDLED_BUSTED=OFF "${NEOVIM_DIR}/third-party/"
+          cmake -G Ninja -DUSE_BUNDLED_BUSTED=OFF "${NEOVIM_DIR}/cmake.deps/"
           ninja
 
       - name: Cleanup src/


### PR DESCRIPTION
https://github.com/neovim/neovim/pull/19120 restructured the layout of
the CMake directories in Neovim.  The main impact is that third-party/
was renamed to cmake.deps/.
